### PR TITLE
Make autologon after register and post content in notification email optional

### DIFF
--- a/MVCForum.Core/DomainModel/Entities/Settings.cs
+++ b/MVCForum.Core/DomainModel/Entities/Settings.cs
@@ -65,5 +65,7 @@ namespace MVCForum.Domain.DomainModel
         public bool? DisableStandardRegistration { get; set; }
         public virtual MembershipRole NewMemberStartingRole { get; set; }
         public virtual Language DefaultLanguage { get; set; }
+        public bool ShowPostContent { get; set; }
+        public bool AutoLoginAfterRegister { get; set; }
     }
 }

--- a/MVCForum.Services/Data/Mapping/SettingsMapping.cs
+++ b/MVCForum.Services/Data/Mapping/SettingsMapping.cs
@@ -61,7 +61,9 @@ namespace MVCForum.Services.Data.Mapping
             Property(x => x.AgreeToTermsAndConditions).IsOptional();
             Property(x => x.DisableStandardRegistration).IsOptional();
             Property(x => x.TermsAndConditions).IsOptional();
-
+            Property(x => x.ShowPostContent).IsOptional();
+            Property(x => x.AutoLoginAfterRegister).IsOptional();
+            
             HasRequired(t => t.NewMemberStartingRole)
                 .WithOptional(x => x.Settings).Map(m => m.MapKey("NewMemberStartingRole"));
 

--- a/MVCForum.Services/Migrations/Configuration.cs
+++ b/MVCForum.Services/Migrations/Configuration.cs
@@ -218,7 +218,9 @@ namespace MVCForum.Services.Migrations
                         EnablePolls = true,
                         MarkAsSolutionReminderTimeFrame = 7,
                         EnableEmoticons = true,
-                        DisableStandardRegistration = false
+                        DisableStandardRegistration = false,
+                        ShowPostContent = false,    
+                        AutoLoginAfterRegister = false                    
                     };
 
                     context.Setting.Add(settings);

--- a/MVCForum.Services/Migrations/Configuration.cs
+++ b/MVCForum.Services/Migrations/Configuration.cs
@@ -219,8 +219,8 @@ namespace MVCForum.Services.Migrations
                         MarkAsSolutionReminderTimeFrame = 7,
                         EnableEmoticons = true,
                         DisableStandardRegistration = false,
-                        ShowPostContent = false,    
-                        AutoLoginAfterRegister = false                    
+                        ShowPostContent = true,    
+                        AutoLoginAfterRegister = true                    
                     };
 
                     context.Setting.Add(settings);

--- a/MVCForum.Website/Areas/Admin/ViewModels/SettingsViewModels.cs
+++ b/MVCForum.Website/Areas/Admin/ViewModels/SettingsViewModels.cs
@@ -199,5 +199,12 @@ namespace MVCForum.Website.Areas.Admin.ViewModels
         [UIHint(AppConstants.EditorType), AllowHtml]
         [StringLength(6000)]
         public string TermsAndConditions { get; set; }
+
+        [DisplayName("Show Post Content In Notifications")]
+        public bool ShowPostContent { get; set; }
+
+        [DisplayName("Auto Login After Registration")]
+        public bool AutoLoginAfterRegister { get; set; }
+
     }
 }

--- a/MVCForum.Website/Areas/Admin/Views/Settings/Index.cshtml
+++ b/MVCForum.Website/Areas/Admin/Views/Settings/Index.cshtml
@@ -67,6 +67,14 @@
             </div>
 
             <div class="checkbox">
+                @using (Html.BeginLabelFor(m => m.AutoLoginAfterRegister, new { @class = "checkbox" }))
+                    {
+                        @Html.CheckBoxFor(m => m.AutoLoginAfterRegister)
+                    }
+                @Html.ValidationMessageFor(m => m.AutoLoginAfterRegister)
+            </div>
+
+            <div class="checkbox">
                 @using (Html.BeginLabelFor(m => m.EnableRSSFeeds, new {@class = "checkbox"}))
                 {
                     @Html.CheckBoxFor(m => m.EnableRSSFeeds)
@@ -182,6 +190,14 @@
                     @Html.CheckBoxFor(m => m.EnableSignatures)
                 }
                 @Html.ValidationMessageFor(m => m.EnableSignatures)
+            </div>
+
+            <div class="checkbox">
+                @using (Html.BeginLabelFor(m => m.ShowPostContent, new { @class = "checkbox" }))
+                {
+                    @Html.CheckBoxFor(m => m.ShowPostContent)
+                }
+                @Html.ValidationMessageFor(m => m.ShowPostContent)
             </div>
 
             <div class="form-group">

--- a/MVCForum.Website/Controllers/MembersController.cs
+++ b/MVCForum.Website/Controllers/MembersController.cs
@@ -505,9 +505,12 @@ namespace MVCForum.Website.Controllers
                 };
             }
             else
-            {
-                // If not manually authorise then log the user in
-                FormsAuthentication.SetAuthCookie(userToSave.UserName, false);
+            {                
+                if (SettingsService.GetSettings().AutoLoginAfterRegister == true)
+                {
+                    FormsAuthentication.SetAuthCookie(userToSave.UserName, false);
+                }
+
                 TempData[AppConstants.MessageViewBagName] = new GenericMessageViewModel
                 {
                     Message = LocalizationService.GetResourceString("Members.NowRegistered"),

--- a/MVCForum.Website/Controllers/PostController.cs
+++ b/MVCForum.Website/Controllers/PostController.cs
@@ -239,7 +239,14 @@ namespace MVCForum.Website.Controllers
                         // Create the email
                         var sb = new StringBuilder();
                         sb.AppendFormat("<p>{0}</p>", string.Format(LocalizationService.GetResourceString("Post.Notification.NewPosts"), topic.Name));
-                        sb.Append(AppHelpers.ConvertPostContent(topic.LastPost.PostContent));
+                        if (SettingsService.GetSettings().ShowPostContent == true)
+                            {
+                            sb.Append(AppHelpers.ConvertPostContent(topic.LastPost.PostContent));
+                        }
+                        else
+                        {
+                            sb.Append("<br />");
+                        }
                         sb.AppendFormat("<p><a href=\"{0}\">{0}</a></p>", string.Concat(SettingsService.GetSettings().ForumUrl.TrimEnd('/'), topic.NiceUrl));
 
                         // create the emails only to people who haven't had notifications disabled
@@ -248,7 +255,7 @@ namespace MVCForum.Website.Controllers
                             Body = _emailService.EmailTemplate(user.UserName, sb.ToString()),
                             EmailTo = user.Email,
                             NameTo = user.UserName,
-                            Subject = string.Concat(LocalizationService.GetResourceString("Post.Notification.Subject"), SettingsService.GetSettings().ForumName)
+                            Subject = string.Concat(LocalizationService.GetResourceString("Post.Notification.Subject"), " ", SettingsService.GetSettings().ForumName)
                         }).ToList();
 
                         // and now pass the emails in to be sent

--- a/MVCForum.Website/ViewModels/Mapping/ViewModelMapping.cs
+++ b/MVCForum.Website/ViewModels/Mapping/ViewModelMapping.cs
@@ -132,6 +132,8 @@ namespace MVCForum.Website.ViewModels.Mapping
             existingSettings.AgreeToTermsAndConditions = settingsViewModel.AgreeToTermsAndConditions;
             existingSettings.DisableStandardRegistration = settingsViewModel.DisableStandardRegistration;
             existingSettings.TermsAndConditions = settingsViewModel.TermsAndConditions;
+            existingSettings.ShowPostContent = settingsViewModel.ShowPostContent;
+            existingSettings.AutoLoginAfterRegister = settingsViewModel.AutoLoginAfterRegister;
             return existingSettings;
         }
 
@@ -189,7 +191,9 @@ namespace MVCForum.Website.ViewModels.Mapping
                 DisableDislikeButton = currentSettings.DisableDislikeButton,
                 TermsAndConditions = currentSettings.TermsAndConditions,
                 AgreeToTermsAndConditions = currentSettings.AgreeToTermsAndConditions ?? false,
-                DisableStandardRegistration = currentSettings.DisableStandardRegistration ?? false
+                DisableStandardRegistration = currentSettings.DisableStandardRegistration ?? false,
+                ShowPostContent = currentSettings.ShowPostContent,
+                AutoLoginAfterRegister = currentSettings.AutoLoginAfterRegister
             };
 
             return settingViewModel;


### PR DESCRIPTION
We use MVCForums auth along with our site's auth for perceived SSO. Due to some registration constraints on our end, we don't want the autologon after registration.

We also had a request from our staff to remove the post content from the post notification emails as our forum users were replying to the notification emails instead of posting their responses back to the forum.

We decided to make both of these optional features available to activate/deactivate from the main settings page