### PR TITLE
Management of role permissions for categories in Admin area.

### DIFF
--- a/.vs/config/applicationhost.config
+++ b/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="MVCForum.Website" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Users\Lee\Dropbox\Projects\MVCForum\MVCForum.Website" />
+                    <virtualDirectory path="/" physicalPath="C:\GIT\mvcforum\MVCForum.Website" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:9666:localhost" />

--- a/MVCForum.Website/Areas/Admin/Controllers/PermissionsController.cs
+++ b/MVCForum.Website/Areas/Admin/Controllers/PermissionsController.cs
@@ -76,6 +76,24 @@ namespace MVCForum.Website.Areas.Admin.Controllers
             }
         }
 
+        public ActionResult EditCategoryPermissions(Guid id)
+        {
+            using (UnitOfWorkManager.NewUnitOfWork())
+            {
+                var category = _categoryService.Get(id);
+                var catPermissionViewModel = new EditCategoryPermissionsViewModel
+                {
+                    Category = category,
+                    Permissions = _permissionService.GetAll().ToList(),
+                    Roles = _roleService.AllRoles()
+                        .Where(x => x.RoleName != AppConstants.AdminRoleName)
+                        .OrderBy(x => x.RoleName)
+                        .ToList()
+                };
+                return View(catPermissionViewModel);
+            }
+        }
+
         public ActionResult PermissionTypes()
         {
             var permViewModel = new ChoosePermissionsViewModel{

--- a/MVCForum.Website/Areas/Admin/ViewModels/PermissionsViewModels.cs
+++ b/MVCForum.Website/Areas/Admin/ViewModels/PermissionsViewModels.cs
@@ -21,6 +21,13 @@ namespace MVCForum.Website.Areas.Admin.ViewModels
         public PermissionSet CurrentGlobalPermissions { get; set; }
     }
 
+    public class EditCategoryPermissionsViewModel
+    {
+        public Category Category { get; set; }
+        public List<Permission> Permissions { get; set; }
+        public List<MembershipRole> Roles { get; set; }
+    }
+
     public class AddTypeViewModel
     {
         [HiddenInput]

--- a/MVCForum.Website/Areas/Admin/Views/AdminCategory/EditCategory.cshtml
+++ b/MVCForum.Website/Areas/Admin/Views/AdminCategory/EditCategory.cshtml
@@ -9,6 +9,13 @@
 <div class="panel">
     <div class="panel-heading">
         <h5>@ViewBag.Title</h5>
+        @if(Model.Id != Guid.Empty) {
+            <div class="pull-right">
+                <a href="@Url.Action("EditCategoryPermissions", "Permissions", new {Model.Id})"
+                   style="margin-left: 10px; margin-top: -7px;" role="button"
+                   class="btn-mvc-green">Role Permissions</a>
+            </div>
+        }
     </div>
     <div class="panel-content">
         @using (Html.BeginForm("EditCategory", "AdminCategory", FormMethod.Post, new { enctype = "multipart/form-data" }))

--- a/MVCForum.Website/Areas/Admin/Views/Permissions/EditCategoryPermissions.cshtml
+++ b/MVCForum.Website/Areas/Admin/Views/Permissions/EditCategoryPermissions.cshtml
@@ -1,0 +1,100 @@
+﻿@using MVCForum.Domain.Constants
+@using MVCForum.Domain.DomainModel
+@model MVCForum.Website.Areas.Admin.ViewModels.EditCategoryPermissionsViewModel
+@{
+    ViewBag.Title = "Edit Permissions";
+    var allPermission = Model.Category.CategoryPermissionForRoles;
+}
+@section AdminPageHeader
+{
+    Edit Role Permissions for Category @Model.Category.Name <img src="@Url.Content("~/Content/admin/Images/ajax-loader.gif")" alt="Please Wait" style="display: none;" class="editpermissionsspinner" /> <span class="label label-success ajaxsuccessshow" style="display: none;">Success</span>
+}
+<div class="backbutton">
+    <a href="@Url.Action("EditCategory", "AdminCategory", new {Id = Model.Category.Id})" class="btn-mvc-green">&lt;&lt; Go Back</a>
+</div>
+<div class="panel">
+    <div class="panel-heading">
+        <h5>Role Permissions</h5>
+    </div>
+    <div class="panel-content">
+
+        <p>Role permissions are all actions a role is allowed to do (Or not do) within a specific category.</p>
+        <div class="tablescroll">
+            <table class="table table-bordered table-striped permissiontable">
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        @foreach (var permissionType in Model.Permissions.Where(x => !x.IsGlobal))
+                        {
+                            <th>@permissionType.Name</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var role in Model.Roles)
+                    {
+                        <tr>
+                            <td style="width:160px;">
+                                @role.RoleName
+                            </td>
+                            @foreach (var permission in Model.Permissions.Where(x => !x.IsGlobal))
+                            {
+                                var isChecked = "";
+                                var isDisabled = DisableCheckBox(permission.Name, role.RoleName);
+                                var catPermission = allPermission.FirstOrDefault(x => x.Permission.Id == permission.Id && x.MembershipRole.Id == role.Id && x.Category.Id == Model.Category.Id);
+                                <td>
+                                    @if (catPermission != null)
+                                    {
+                                        // bingo we have this permission
+                                        isChecked = catPermission.IsTicked ? " checked" : "";
+                                    }
+                                    <span class="permissioncheckbox">
+                                        <input data-permisssion="@permission.Id" data-category="@Model.Category.Id" data-role="@role.Id" type="checkbox" id="@permission.Id-@Model.Category.Id" @isChecked @isDisabled />
+                                    </span>
+                                </td>
+                            }
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<div class="panel">
+    <div class="panel-heading">
+        <h5>Descriptions</h5>
+    </div>
+    <div class="panel-content">
+        <h6>@SiteConstants.Instance.PermissionAttachFiles</h6>
+        <p>If you tick this permission, users in this role will be able to attach files to topics and posts for download (file types and size can be restricted in web.config app settings - FileUploadAllowedExtensions and FileUploadMaximumFileSizeInBytes)</p>
+        <h6>@SiteConstants.Instance.PermissionCreatePolls</h6>
+        <p>If you tick this, then users in this role will be able to create polls in a topic.</p>
+        <h6>@SiteConstants.Instance.PermissionVoteInPolls</h6>
+        <p>If you tick this, users in this role will be able to vote in polls (As long as Create Polls is enabled)</p>
+        <h6>@SiteConstants.Instance.PermissionCreateTopics</h6>
+        <p>If you tick this, users in this role will be able to create topics</p>
+        <h6>@SiteConstants.Instance.PermissionDeletePosts</h6>
+        <p>If you tick this, users in this role will be able to delete other users posts and topics (Good Moderator permission)</p>
+        <h6>@SiteConstants.Instance.PermissionEditPosts</h6>
+        <p>If you tick this, users in this role will be able to edit other users posts and topics (Good Moderator permission)</p>
+        <h6>@SiteConstants.Instance.PermissionLockTopics</h6>
+        <p>If you tick this, users in this role will be able to lock topics, stopping any further posting in it.</p>
+        <h6>@SiteConstants.Instance.PermissionCreateStickyTopics</h6>
+        <p>If you tick this, users in this role will be able to make a sticky topic (Pin the topic) which will always be shown at the top of a category.</p>
+        <h6>@SiteConstants.Instance.PermissionReadOnly</h6>
+        <p>If you tick this, users in this role will not be able to post in the Category.</p>
+        <h6>@SiteConstants.Instance.PermissionDenyAccess</h6>
+        <p>If you tick this, users will not be able to access or see the Category - Also they won't be able to see any posts, topics or tags that were created in it either (Private Categories).</p>
+    </div>
+</div>
+@helper DisableCheckBox(string permissionName, string roleName)
+{
+if (roleName == AppConstants.GuestRoleName && permissionName != SiteConstants.Instance.PermissionDenyAccess)
+{
+        <text>disabled</text>
+}
+else
+{
+        <text></text>
+}
+}

--- a/MVCForum.Website/MVCForum.Website.csproj
+++ b/MVCForum.Website/MVCForum.Website.csproj
@@ -837,6 +837,7 @@
     <Content Include="Scripts\cache\Cache.txt" />
     <Content Include="Content\bootstrap\css\bootstrap-theme.min.css.map" />
     <Content Include="Content\bootstrap\css\bootstrap.min.css.map" />
+    <Content Include="Areas\Admin\Views\Permissions\EditCategoryPermissions.cshtml" />
     <None Include="Scripts\jquery-3.1.0.intellisense.js" />
     <Content Include="Scripts\jquery-3.1.0.js" />
     <Content Include="Scripts\jquery-3.1.0.min.js" />

--- a/MVCForum.Website/Web.config
+++ b/MVCForum.Website/Web.config
@@ -5,7 +5,7 @@
   </configSections>
   <connectionStrings>    
     <!-- IMPORTANT! Don't forget to update the connection string below with your database name/credentials if you don't want to use SQLCE - DO NOT change the connection string name MVCForumContext -->
-    <add name="MVCForumContext" connectionString="data source=DESKTOP-SIJ1U6G;database=MVCForum;Trusted_Connection=True;" providerName="System.Data.SqlClient" />
+    <add name="MVCForumContext" connectionString="data source=localhost\sqlexpress;database=DevMVCForum;Trusted_Connection=True;" providerName="System.Data.SqlClient" />
     <!--<add name="MVCForumContext" connectionString="Data Source=|DataDirectory|\MVCForum.sdf" providerName="System.Data.SqlServerCe.4.0" />-->
   </connectionStrings>
 


### PR DESCRIPTION
I found it handy to have a permission management for roles. Because the more roles you'll have in your forum the more cumbersome it gets to initialize the rights of a newly added category. The role permissions of a category can be called from the category edit form (button at the right of the panel header).

@YodasMyDad - Please ignore the config-files and the csproj-file 😉
