### PR TITLE
New activity types (PostCreated, TopicCreated) for Activity Page

### DIFF
--- a/MVCForum.Core/DomainModel/Activity/Activity.cs
+++ b/MVCForum.Core/DomainModel/Activity/Activity.cs
@@ -8,6 +8,8 @@ namespace MVCForum.Domain.DomainModel.Activity
         BadgeAwarded,
         MemberJoined,
         ProfileUpdated,
+        PostCreated,
+        TopicCreated
     }
 
     public class Activity : Entity

--- a/MVCForum.Core/DomainModel/Activity/PostCreatedActivity.cs
+++ b/MVCForum.Core/DomainModel/Activity/PostCreatedActivity.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace MVCForum.Domain.DomainModel.Activity
+{
+    public class PostCreatedActivity : ActivityBase
+    {
+        public Post Post { get; set; }
+
+        public PostCreatedActivity(Activity activity, Post post)
+        {
+            ActivityMapped = activity;
+            Post = post;
+        }
+
+        public static Activity GenerateMappedRecord(Post post, DateTime timestamp)
+        {
+            return new Activity
+            {                
+                Data = post.Id.ToString(),
+                Timestamp = timestamp,
+                Type = ActivityType.PostCreated.ToString()
+            };
+        }
+    }
+}

--- a/MVCForum.Core/DomainModel/Activity/TopicCreatedActivity.cs
+++ b/MVCForum.Core/DomainModel/Activity/TopicCreatedActivity.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace MVCForum.Domain.DomainModel.Activity
+{
+    public class TopicCreatedActivity : ActivityBase
+    {
+        public Topic Topic { get; set; }
+
+        public TopicCreatedActivity(Activity activity, Topic topic)
+        {
+            ActivityMapped = activity;
+            Topic = topic;
+        }
+
+        public static Activity GenerateMappedRecord(Topic topic, DateTime timestamp)
+        {
+            return new Activity
+            {
+                Data = topic.Id.ToString(),
+                Timestamp = timestamp,
+                Type = ActivityType.TopicCreated.ToString()
+            };
+
+        }
+    }
+}

--- a/MVCForum.Core/Interfaces/Services/IActivityService.cs
+++ b/MVCForum.Core/Interfaces/Services/IActivityService.cs
@@ -12,8 +12,9 @@ namespace MVCForum.Domain.Interfaces.Services
         /// </summary>
         /// <param name="pageIndex"></param>
         /// <param name="pageSize"></param>
+        /// <param name="usersRole"></param>
         /// <returns></returns>
-        PagedList<ActivityBase> GetPagedGroupedActivities(int pageIndex, int pageSize);
+        PagedList<ActivityBase> GetPagedGroupedActivities(int pageIndex, int pageSize, MembershipRole usersRole);
 
         /// <summary>
         /// Gets all activities by search data field for a Guid
@@ -48,6 +49,18 @@ namespace MVCForum.Domain.Interfaces.Services
         /// </summary>
         /// <param name="user"></param>
         void ProfileUpdated(MembershipUser user);
+
+        /// <summary>
+        /// Post has been created
+        /// </summary>
+        /// <param name="post"></param>
+        void PostCreated(Post post);
+
+        /// <summary>
+        /// Topic has been created
+        /// </summary>
+        /// <param name="topic"></param>
+        void TopicCreated(Topic topic);
 
         /// <summary>
         /// Delete a number of activities

--- a/MVCForum.Core/MVCForum.Domain.csproj
+++ b/MVCForum.Core/MVCForum.Domain.csproj
@@ -82,8 +82,10 @@
     <Compile Include="Constants\SiteConstants.cs" />
     <Compile Include="DomainModel\Activity\ActivityBase.cs" />
     <Compile Include="DomainModel\Activity\BadgeActivity.cs" />
+    <Compile Include="DomainModel\Activity\PostCreatedActivity.cs" />
     <Compile Include="DomainModel\Activity\ProfileUpdatedActivity.cs" />
     <Compile Include="DomainModel\Activity\MemberJoinedActivity.cs" />
+    <Compile Include="DomainModel\Activity\TopicCreatedActivity.cs" />
     <Compile Include="DomainModel\Attributes\AwardsPointsAttribute.cs" />
     <Compile Include="DomainModel\Attributes\DisplayNameAttribute.cs" />
     <Compile Include="DomainModel\Attributes\ImageAttribute.cs" />

--- a/MVCForum.Services/ActivityService.cs
+++ b/MVCForum.Services/ActivityService.cs
@@ -3,6 +3,7 @@
     using Domain.Constants;
     using System;
     using System.Collections.Generic;
+using System.Data.Entity;
     using System.Linq;
     using Domain.DomainModel;
     using Domain.DomainModel.Activity;
@@ -15,15 +16,21 @@
     {
         private readonly MVCForumContext _context;
         private readonly IBadgeService _badgeService;
+        private readonly ITopicService _topicService;
+        private readonly IPostService _postService;
+        private readonly ICategoryService _categoryService;
         private readonly ILoggingService _loggingService;
         private readonly ICacheService _cacheService;
 
         /// <summary>
         /// Constructor
         /// </summary>
-        public ActivityService(IBadgeService badgeService, ILoggingService loggingService, IMVCForumContext context, ICacheService cacheService)
+        public ActivityService(IBadgeService badgeService, ITopicService topicService, IPostService postService, ICategoryService categoryService, ILoggingService loggingService, IMVCForumContext context, ICacheService cacheService)
         {
             _badgeService = badgeService;
+            _postService = postService;
+            _topicService = topicService;
+            _categoryService = categoryService;
             _loggingService = loggingService;
             _cacheService = cacheService;
             _context = context as MVCForumContext;
@@ -144,6 +151,56 @@
         }
 
         /// <summary>
+        /// Make a post created activity object from the more generic database activity object
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <returns></returns>
+        private PostCreatedActivity GeneratePostCreatedActivity(Activity activity)
+        {
+            var cacheKey = string.Concat(CacheKeys.Activity.StartsWith, "GeneratePostCreatedActivity-", activity.GetHashCode());
+            return _cacheService.CachePerRequest(cacheKey, () =>
+            {
+                var postGuid = Guid.Parse(activity.Data);
+
+                var post = _postService.Get(postGuid);
+
+                if (post == null)
+                {
+                    // Log the problem then skip
+                    _loggingService.Error($"A post created activity record with id '{activity.Id}' has a post id '{postGuid}' that is not found in the post table.");
+                    return null;                   
+                }
+
+                return new PostCreatedActivity(activity, post);
+            });
+        }
+
+        /// <summary>
+        /// Make a topic created activity object from the more generic database activity object
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <returns></returns>
+        private TopicCreatedActivity GenerateTopicCreatedActivity(Activity activity)
+        {
+            var cacheKey = string.Concat(CacheKeys.Activity.StartsWith, "GenerateTopicCreatedActivity-", activity.GetHashCode());
+            return _cacheService.CachePerRequest(cacheKey, () =>
+            {
+                var topicGuid = Guid.Parse(activity.Data);
+
+                var topic = _topicService.Get(topicGuid);
+
+                if (topic == null)
+                {
+                    // Log the problem then skip
+                    _loggingService.Error($"A topic created activity record with id '{activity.Id}' has a topic id '{topicGuid}' that is not found in the topic table.");
+                    return null;
+                }
+
+                return new TopicCreatedActivity(activity, topic);
+            });
+        }
+
+        /// <summary>
         /// Converts a paged list of generic activities into a paged list of more specific activity instances
         /// </summary>
         /// <param name="activities">Paged list of activities where each member may be a specific activity instance e.g. a profile updated activity</param>
@@ -202,10 +259,28 @@
                             listedResults.Add(profileUpdatedActivity);
                         }
                     }
+                    else if (activity.Type == ActivityType.PostCreated.ToString())
+                    {
+                        var postCreatedActivity = GeneratePostCreatedActivity(activity);
+
+                        if (postCreatedActivity != null)
+                        {
+                            listedResults.Add(postCreatedActivity);
+                        }
+                    }
+                    else if (activity.Type == ActivityType.TopicCreated.ToString())
+                    {
+                        var topicCreatedActivity = GenerateTopicCreatedActivity(activity);
+
+                        if (topicCreatedActivity != null)
+                        {
+                            listedResults.Add(topicCreatedActivity);
+                        }
+                    }
                 }
                 return listedResults;
             });
-        } 
+        }
         #endregion
 
         /// <summary>
@@ -213,22 +288,32 @@
         /// </summary>
         /// <param name="pageIndex"></param>
         /// <param name="pageSize"></param>
+        /// <param name="usersRole"></param>
         /// <returns></returns>
-        public PagedList<ActivityBase> GetPagedGroupedActivities(int pageIndex, int pageSize)
+        public PagedList<ActivityBase> GetPagedGroupedActivities(int pageIndex, int pageSize, MembershipRole usersRole)
         {
             // Read the database for all activities and convert each to a more specialised activity type
 
             var cacheKey = string.Concat(CacheKeys.Activity.StartsWith, "GetPagedGroupedActivities-", pageIndex, "-", pageSize);
             return _cacheService.CachePerRequest(cacheKey, () =>
             {
-                var totalCount = _context.Activity.Count();
-                var results = _context.Activity
-                      .OrderByDescending(x => x.Timestamp)
-                      .Skip((pageIndex - 1) * pageSize)
-                      .Take(pageSize)
-                      .ToList();
+                List<Category> allowedCategories = _categoryService.GetAllowedCategories(usersRole);
+                IEnumerable<Guid> allowedCatIds = allowedCategories.Select(x => x.Id);
 
-                // Return a paged list
+                var query = 
+                    from activity in _context.Activity
+                    where ((activity.Type != ActivityType.TopicCreated.ToString()) || _context.Topic.Where(p => allowedCatIds.Contains(p.Category.Id)).Select(q => q.Id.ToString()).Contains(activity.Data)) &&
+                          ((activity.Type != ActivityType.PostCreated.ToString()) || _context.Post.Where(p => allowedCatIds.Contains(p.Topic.Category.Id)).Select(q => q.Id.ToString()).Contains(activity.Data))
+                    select activity;                
+
+                var totalCount = query.Count();
+
+                var results = query.OrderByDescending(x => x.Timestamp)
+                    .Skip((pageIndex - 1)*pageSize)
+                    .Take(pageSize)
+                    .ToList();
+
+                 // Return a paged list
                 var activities = new PagedList<Activity>(results, pageIndex, pageSize, totalCount);
 
                 // Convert
@@ -236,7 +321,6 @@
 
                 return specificActivities;
             });
-
         }
 
         /// <summary>
@@ -318,6 +402,26 @@
         {
             var profileUpdatedActivity = ProfileUpdatedActivity.GenerateMappedRecord(user, DateTime.UtcNow);
             Add(profileUpdatedActivity);
+        }
+
+        /// <summary>
+        /// Post has been created
+        /// </summary>
+        /// <param name="post"></param>
+        public void PostCreated(Post post)
+        {
+            var postCreatedActivity = PostCreatedActivity.GenerateMappedRecord(post, DateTime.UtcNow);
+            Add(postCreatedActivity);
+        }
+
+        /// <summary>
+        /// Topic has been created
+        /// </summary>
+        /// <param name="topic"></param>
+        public void TopicCreated(Topic topic)
+        {
+            var topicCreatedActivity = TopicCreatedActivity.GenerateMappedRecord(topic, DateTime.UtcNow);
+            Add(topicCreatedActivity);
         }
 
         /// <summary>

--- a/MVCForum.Utilities/StringUtils.cs
+++ b/MVCForum.Utilities/StringUtils.cs
@@ -79,6 +79,21 @@ namespace MVCForum.Utilities
             var results = source.IndexOf(value, StringComparison.CurrentCultureIgnoreCase);
             return results != -1;
         }
+
+        /// <summary>
+        /// Truncate long string
+        /// </summary>
+        /// <param name="str"></param>
+        /// <param name="maxLength"></param>
+        /// <param name="addSuffix">Add a suffix '...' in case of truncation</param>
+        /// <returns></returns>
+        public static string TruncateLongString(this string str, int maxLength, bool addSuffix)
+        {
+            if (str.Length <= maxLength)
+                return str;
+
+            return str.Substring(0, maxLength) + (addSuffix ? "..." : "");
+        }
         #endregion
 
         #region Social Helpers

--- a/MVCForum.Website/Controllers/HomeController.cs
+++ b/MVCForum.Website/Controllers/HomeController.cs
@@ -98,7 +98,7 @@
                 var pageIndex = p ?? 1;
 
                 // Get the topics
-                var activities = _activityService.GetPagedGroupedActivities(pageIndex, SettingsService.GetSettings().ActivitiesPerPage);
+                var activities = _activityService.GetPagedGroupedActivities(pageIndex, SettingsService.GetSettings().ActivitiesPerPage, UsersRole);
 
                 // create the view model
                 var viewModel = new AllRecentActivitiesViewModel

--- a/MVCForum.Website/Controllers/ModerateController.cs
+++ b/MVCForum.Website/Controllers/ModerateController.cs
@@ -13,15 +13,17 @@
         private readonly IPostService _postService;
         private readonly ITopicService _topicService;
         private readonly ICategoryService _categoryService;
+        private readonly IActivityService _activityService;
 
         public ModerateController(ILoggingService loggingService, IUnitOfWorkManager unitOfWorkManager, IMembershipService membershipService, 
             ILocalizationService localizationService, IRoleService roleService, ISettingsService settingsService, IPostService postService, 
-            ITopicService topicService, ICategoryService categoryService, ICacheService cacheService) 
+            ITopicService topicService, IActivityService activityService, ICategoryService categoryService, ICacheService cacheService) 
             : base(loggingService, unitOfWorkManager, membershipService, localizationService, roleService, settingsService, cacheService)
         {
             _postService = postService;
             _topicService = topicService;
             _categoryService = categoryService;
+            _activityService = activityService;
         }
 
         public ActionResult Index()
@@ -56,6 +58,7 @@
                     if (viewModel.IsApproved)
                     {
                         topic.Pending = false;
+                        _activityService.TopicCreated(topic);
                     }
                     else
                     {
@@ -93,6 +96,7 @@
                     if (viewModel.IsApproved)
                     {
                         post.Pending = false;
+                        _activityService.PostCreated(post);
                     }
                     else
                     {

--- a/MVCForum.Website/Controllers/TopicController.cs
+++ b/MVCForum.Website/Controllers/TopicController.cs
@@ -39,12 +39,13 @@
         private readonly IVoteService _voteService;
         private readonly IUploadedFileService _uploadedFileService;
         private readonly IPostEditService _postEditService;
+        private readonly IActivityService _activityService;
 
         public TopicController(ILoggingService loggingService, IUnitOfWorkManager unitOfWorkManager, IMembershipService membershipService, IRoleService roleService, ITopicService topicService, IPostService postService,
             ICategoryService categoryService, ILocalizationService localizationService, ISettingsService settingsService, ITopicTagService topicTagService, IMembershipUserPointsService membershipUserPointsService,
             ICategoryNotificationService categoryNotificationService, IEmailService emailService, ITopicNotificationService topicNotificationService, IPollService pollService,
             IPollAnswerService pollAnswerService, IBannedWordService bannedWordService, IVoteService voteService, IFavouriteService favouriteService, IUploadedFileService uploadedFileService, ICacheService cacheService, 
-            ITagNotificationService tagNotificationService, IPostEditService postEditService)
+            ITagNotificationService tagNotificationService, IPostEditService postEditService, IActivityService activityService)
             : base(loggingService, unitOfWorkManager, membershipService, localizationService, roleService, settingsService, cacheService)
         {
             _topicService = topicService;
@@ -63,6 +64,7 @@
             _uploadedFileService = uploadedFileService;
             _tagNotificationService = tagNotificationService;
             _postEditService = postEditService;
+            _activityService = activityService;
         }
 
 
@@ -935,6 +937,9 @@
                             {
                                 cancelledByEvent = true;
                             }
+
+                            if (!topic.Pending.HasValue || !topic.Pending.Value)
+                                _activityService.TopicCreated(topic);
 
                             try
                             {

--- a/MVCForum.Website/Views/Home/Activity.cshtml
+++ b/MVCForum.Website/Views/Home/Activity.cshtml
@@ -1,5 +1,5 @@
 ﻿@using MVCForum.Domain.DomainModel.Activity;
-@using MVCForum.Website
+@using MVCForum.Utilities
 @using MVCForum.Website.Application
 @using MVCForum.Website.ViewModels
 @model AllRecentActivitiesViewModel
@@ -83,6 +83,50 @@
                         <p class="activityinfotext"><a href="@Html.Raw(profileUpdatedActivity.User.NiceUrl)">@Html.Raw(profileUpdatedActivity.User.UserName)</a> @Html.LanguageString("Activity.ProfileUpdated")</p>
                         <p class="activitysubdate">
                            @DatesUI.GetPrettyDate(profileUpdatedActivity.ActivityMapped.Timestamp.ToString())
+                        </p>
+                    </div>
+                </div>
+            }
+            else if (activity is PostCreatedActivity)
+            {
+                var postCreatedActivity = activity as PostCreatedActivity;
+                <div class="row postcreatedactivity">
+                    <div class="activitybadge col-md-1">
+                        <img src="@postCreatedActivity.Post.User.MemberImage(SiteConstants.Instance.GravatarPostSize)" alt="@postCreatedActivity.Post.User.UserName" />
+                    </div>
+
+                    <div class="activityinfo col-md-11">
+                        <p class="activityinfotext">
+                            <a href="@Html.Raw(postCreatedActivity.Post.User.NiceUrl)">@Html.Raw(postCreatedActivity.Post.User.UserName)</a> replied to <a href="@Html.Raw(postCreatedActivity.Post.Topic.NiceUrl)">@Html.Raw(postCreatedActivity.Post.Topic.Name)</a> in <a href="@Html.Raw(postCreatedActivity.Post.Topic.Category.NiceUrl)">@Html.Raw(postCreatedActivity.Post.Topic.Category.Name)</a>
+                        </p>
+
+                        <div class="activitybadgedescription">                        
+                            @Html.Raw(StringUtils.SafePlainText(postCreatedActivity.Post.PostContent).TruncateLongString(200, true)) <a href="@Html.Raw(postCreatedActivity.Post.Topic.NiceUrl + "#comment-" + postCreatedActivity.Post.Id)">go to post</a>
+                        </div>                             
+                        <p class="activitysubdate">
+                            @DatesUI.GetPrettyDate(postCreatedActivity.ActivityMapped.Timestamp.ToString())
+                        </p>                      
+                    </div>
+                </div>
+            }
+            else if (activity is TopicCreatedActivity)
+            {
+                var topicCreatedActivity = activity as TopicCreatedActivity;
+                <div class="row topiccreatedactivity">
+                    <div class="activitybadge col-md-1">
+                        <img src="@topicCreatedActivity.Topic.User.MemberImage(SiteConstants.Instance.GravatarPostSize)" alt="@topicCreatedActivity.Topic.User.UserName" />
+                    </div>
+
+                    <div class="activityinfo col-md-11">
+                        <p class="activityinfotext">
+                            <a href="@Html.Raw(topicCreatedActivity.Topic.User.NiceUrl)">@Html.Raw(topicCreatedActivity.Topic.User.UserName)</a> started a topic <a href="@Html.Raw(topicCreatedActivity.Topic.NiceUrl)">@Html.Raw(topicCreatedActivity.Topic.Name)</a> in <a href="@Html.Raw(topicCreatedActivity.Topic.Category.NiceUrl)">@Html.Raw(topicCreatedActivity.Topic.Category.Name)</a>
+                        </p>
+
+                        <div class="activitybadgedescription">
+                            @Html.Raw(StringUtils.SafePlainText(topicCreatedActivity.Topic.Posts.First().PostContent).TruncateLongString(200, true)) <a href="@Html.Raw(topicCreatedActivity.Topic.NiceUrl)">go to topic</a>
+                        </div>
+                        <p class="activitysubdate">
+                            @DatesUI.GetPrettyDate(topicCreatedActivity.ActivityMapped.Timestamp.ToString())
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
Hello, 
I suggest to extend Activity Page and add new activity types - PostCreated and TopicCreated.
Please see screenshot http://moifotki.org/i/fd68a0ec827d8f3ef040ebb091988554

**Advantages:** 
- Activity Page almost the same as for VBulletin 4
- I hope this improvement is compatible with project Dialogue

**Disadvantages:**
- A heavier EF query (we should do not forget about the category permissions) 
- Database field "Activity.Data" contains "Value" (post Id or topic Id) instead of "Key=Value". But it looks like this is not a big problem.

Thanks.


