### PR TITLE
Added RoleService.GetRoleEquals(string, bool)

### DIFF
--- a/MVCForum.Core/Interfaces/Services/IRoleService.cs
+++ b/MVCForum.Core/Interfaces/Services/IRoleService.cs
@@ -9,7 +9,7 @@
     {
         IList<MembershipRole> AllRoles();
         void Delete(MembershipRole role);
-        MembershipRole GetRole(string rolename, bool removeTracking = false);
+        MembershipRole GetRole(string roleName, bool removeTracking = false);
         MembershipRole GetRoleEquals(string roleName, bool removeTracking = false);
         MembershipRole GetRole(Guid id);
         IList<MembershipUser> GetUsersForRole(string roleName);

--- a/MVCForum.Core/Interfaces/Services/IRoleService.cs
+++ b/MVCForum.Core/Interfaces/Services/IRoleService.cs
@@ -10,6 +10,7 @@
         IList<MembershipRole> AllRoles();
         void Delete(MembershipRole role);
         MembershipRole GetRole(string rolename, bool removeTracking = false);
+        MembershipRole GetRoleEquals(string roleName, bool removeTracking = false);
         MembershipRole GetRole(Guid id);
         IList<MembershipUser> GetUsersForRole(string roleName);
         MembershipRole CreateRole(MembershipRole role);

--- a/MVCForum.Core/Interfaces/Services/IRoleService.cs
+++ b/MVCForum.Core/Interfaces/Services/IRoleService.cs
@@ -10,7 +10,6 @@
         IList<MembershipRole> AllRoles();
         void Delete(MembershipRole role);
         MembershipRole GetRole(string roleName, bool removeTracking = false);
-        MembershipRole GetRoleEquals(string roleName, bool removeTracking = false);
         MembershipRole GetRole(Guid id);
         IList<MembershipUser> GetUsersForRole(string roleName);
         MembershipRole CreateRole(MembershipRole role);

--- a/MVCForum.Core/Services/RoleService.cs
+++ b/MVCForum.Core/Services/RoleService.cs
@@ -56,12 +56,12 @@
         }
 
         /// <summary>
-        /// Get role by name
+        /// Get role by name, returning first role with name containing supplied role name
         /// </summary>
-        /// <param name="rolename"></param>
+        /// <param name="roleName"></param>
         /// <param name="removeTracking">If true, adds AsNoTracking()</param>
         /// <returns></returns>
-        public MembershipRole GetRole(string rolename, bool removeTracking = false)
+        public MembershipRole GetRole(string roleName, bool removeTracking = false)
         {
  
                 if (removeTracking)
@@ -71,10 +71,31 @@
                         .Include(x => x.CategoryPermissionForRoles.Select(p => p.Category))
                         .Include(x => x.GlobalPermissionForRole.Select(p => p.Permission))
                         .AsNoTracking()
-                        .FirstOrDefault(y => y.RoleName.Contains(rolename));
+                        .FirstOrDefault(y => y.RoleName.Contains(roleName));
                 }
-                return _context.MembershipRole.FirstOrDefault(y => y.RoleName.Contains(rolename));
+                return _context.MembershipRole.FirstOrDefault(x => x.RoleName.Contains(roleName));
          
+        }
+
+        /// <summary>
+        /// Get role by name, returning first role with name which equals supplied role name
+        /// </summary>
+        /// <param name="roleName"></param>
+        /// <param name="removeTracking">If true, adds AsNoTracking()</param>
+        /// <returns></returns>
+        public MembershipRole GetRoleEquals(string roleName, bool removeTracking = false)
+        {
+            if (removeTracking)
+            {
+                return _context.MembershipRole
+                    .Include(x => x.CategoryPermissionForRoles.Select(p => p.Permission))
+                    .Include(x => x.CategoryPermissionForRoles.Select(p => p.Category))
+                    .Include(x => x.GlobalPermissionForRole.Select(p => p.Permission))
+                    .AsNoTracking()
+                    .FirstOrDefault(y => y.RoleName == roleName);
+            }
+
+            return _context.MembershipRole.FirstOrDefault(x => x.RoleName == roleName);
         }
 
         /// <summary>

--- a/MVCForum.Core/Services/RoleService.cs
+++ b/MVCForum.Core/Services/RoleService.cs
@@ -56,33 +56,12 @@
         }
 
         /// <summary>
-        /// Get role by name, returning first role with name containing supplied role name
-        /// </summary>
-        /// <param name="roleName"></param>
-        /// <param name="removeTracking">If true, adds AsNoTracking()</param>
-        /// <returns></returns>
-        public MembershipRole GetRole(string roleName, bool removeTracking = false)
-        {
-            if (removeTracking)
-            {
-                return _context.MembershipRole
-                    .Include(x => x.CategoryPermissionForRoles.Select(p => p.Permission))
-                    .Include(x => x.CategoryPermissionForRoles.Select(p => p.Category))
-                    .Include(x => x.GlobalPermissionForRole.Select(p => p.Permission))
-                    .AsNoTracking()
-                    .FirstOrDefault(y => y.RoleName.Contains(roleName));
-            }
-
-            return _context.MembershipRole.FirstOrDefault(x => x.RoleName.Contains(roleName));
-        }
-
-        /// <summary>
         /// Get role by name, returning first role with name which equals supplied role name
         /// </summary>
         /// <param name="roleName"></param>
         /// <param name="removeTracking">If true, adds AsNoTracking()</param>
         /// <returns></returns>
-        public MembershipRole GetRoleEquals(string roleName, bool removeTracking = false)
+        public MembershipRole GetRole(string roleName, bool removeTracking = false)
         {
             if (removeTracking)
             {

--- a/MVCForum.Core/Services/RoleService.cs
+++ b/MVCForum.Core/Services/RoleService.cs
@@ -63,18 +63,17 @@
         /// <returns></returns>
         public MembershipRole GetRole(string roleName, bool removeTracking = false)
         {
- 
-                if (removeTracking)
-                {
-                    return _context.MembershipRole
-                        .Include(x => x.CategoryPermissionForRoles.Select(p => p.Permission))
-                        .Include(x => x.CategoryPermissionForRoles.Select(p => p.Category))
-                        .Include(x => x.GlobalPermissionForRole.Select(p => p.Permission))
-                        .AsNoTracking()
-                        .FirstOrDefault(y => y.RoleName.Contains(roleName));
-                }
-                return _context.MembershipRole.FirstOrDefault(x => x.RoleName.Contains(roleName));
-         
+            if (removeTracking)
+            {
+                return _context.MembershipRole
+                    .Include(x => x.CategoryPermissionForRoles.Select(p => p.Permission))
+                    .Include(x => x.CategoryPermissionForRoles.Select(p => p.Category))
+                    .Include(x => x.GlobalPermissionForRole.Select(p => p.Permission))
+                    .AsNoTracking()
+                    .FirstOrDefault(y => y.RoleName.Contains(roleName));
+            }
+
+            return _context.MembershipRole.FirstOrDefault(x => x.RoleName.Contains(roleName));
         }
 
         /// <summary>


### PR DESCRIPTION
I have been working on implementing custom authentication and authorization in MVCForum using Azure AD B2C. When syncing security groups to the role claim I noticed that `Contains()` extension method was used as predicate. I needed a more "exact" implementation. I also extended the description comments on the methods.